### PR TITLE
Fix calendar date selection in expense form

### DIFF
--- a/app.js
+++ b/app.js
@@ -1981,10 +1981,10 @@ class WorkLifeBalanceApp {
         console.log('Add expense for date called:', dateStr);
         const date = new Date(dateStr);
 
-        // Reset form first
-        this.resetExpenseForm();
+        // Open modal first (this will reset the form)
+        this.openModal('expenseModal');
 
-        // Set the date from calendar selection
+        // Set the date from calendar selection after opening modal
         const dateField = document.getElementById('expenseDate');
         if (dateField) {
             dateField.value = date.toISOString().split('T')[0];
@@ -2003,8 +2003,6 @@ class WorkLifeBalanceApp {
                 day: 'numeric'
             })}`;
         }
-
-        this.openModal('expenseModal');
     }
 
     loadFoodData() {


### PR DESCRIPTION
## Purpose
Fix the issue where clicking a date in the calendar was not properly setting the selected date in the expense form. The user wanted the expense form to automatically populate with the clicked calendar date.

## Code changes
- Reordered the sequence in `addExpenseForDate()` method to open the modal first before setting the date
- Moved `this.openModal('expenseModal')` to execute before setting the date field value
- Added clarifying comments to explain the execution order
- This ensures the form is properly initialized before attempting to set the date value

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bd5d4b1fbb6646ec8fa650ba409f631d/pulse-field)

👀 [Preview Link](https://bd5d4b1fbb6646ec8fa650ba409f631d-pulse-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bd5d4b1fbb6646ec8fa650ba409f631d</projectId>-->
<!--<branchName>pulse-field</branchName>-->